### PR TITLE
Some fixes for Django 2.0

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -276,12 +276,11 @@ class HistoricalRecords(object):
             return instance._history_user
         except AttributeError:
             try:
+                is_authenticated = self.thread.request.user.is_authenticated
                 try:
-                    # Django < 1.10
-                    is_authenticated = self.thread.request.user.is_authenticated()
+                    is_authenticated = is_authenticated() # Django < 1.10
                 except TypeError:
-                    # Django >= 2.0
-                    is_authenticated = self.thread.request.user.is_authenticated
+                    pass
                 if is_authenticated:
                     return self.thread.request.user
                 return None

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -277,15 +277,13 @@ class HistoricalRecords(object):
         except AttributeError:
             try:
                 is_authenticated = self.thread.request.user.is_authenticated
-                try:
-                    is_authenticated = is_authenticated() # Django < 1.10
-                except TypeError:
-                    pass
-                if is_authenticated:
-                    return self.thread.request.user
-                return None
             except AttributeError:
                 return None
+            if not is_authenticated in (True, False):
+                is_authenticated = is_authenticated() # Django < 1.10
+            if is_authenticated:
+                return self.thread.request.user
+            return None
 
 
 def transform_field(field):

--- a/simple_history/registry_tests/migration_test_app/models.py
+++ b/simple_history/registry_tests/migration_test_app/models.py
@@ -11,5 +11,5 @@ class WhatIMean(DoYouKnow):
 
 
 class Yar(models.Model):
-    what = models.ForeignKey(WhatIMean)
+    what = models.ForeignKey(WhatIMean, on_delete=models.CASCADE)
     history = HistoricalRecords()

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -268,7 +268,11 @@ class UserAccessorOverride(models.Model):
 
 
 class Employee(models.Model):
-    manager = models.OneToOneField('Employee', null=True)
+    manager = models.OneToOneField(
+        'Employee',
+        on_delete=models.CASCADE,
+        null=True,
+    )
     history = HistoricalRecords()
 
 

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -6,7 +6,10 @@ from django.contrib.admin import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError: # Django <1.10
+    from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.encoding import force_text

--- a/simple_history/tests/urls.py
+++ b/simple_history/tests/urls.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib import admin
 from . import other_admin
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^other-admin/', include(other_admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
+    url(r'^other-admin/', other_admin.site.urls),
 ]


### PR DESCRIPTION
Some fixes in tests for Django 2.0. Fixed warning for `is_authenticated` in Django 1.10+.
Note: `get_history_user` in `models.HistoricalRecords` always raises the caught `AttributeError` in currently passing tests.